### PR TITLE
Fix controlled inputs for TODO form

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -63,13 +63,13 @@ const App = ({ signOut, user }) => {
         placeholder="Name"
         onChange={(event) => setInput("name", event.target.value)}
         style={styles.input}
-        defaultValue={formState.name}
+        value={formState.name}
       />
       <TextField
         placeholder="Description"
         onChange={(event) => setInput("description", event.target.value)}
         style={styles.input}
-        defaultValue={formState.description}
+        value={formState.description}
       />
       <Button style={styles.button} onClick={addTodo}>
         Create Todo


### PR DESCRIPTION
## Summary
- use `value` rather than `defaultValue` so form fields clear when adding todos

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7375e7e88326bea1910df06d6f99