### PR TITLE
Rename userpoolClient keys

### DIFF
--- a/amplify/backend/auth/visitchicago71d203dc/cli-inputs.json
+++ b/amplify/backend/auth/visitchicago71d203dc/cli-inputs.json
@@ -23,16 +23,16 @@
       "email"
     ],
     "aliasAttributes": [],
-    "userpoolClientGenerateSecret": false,
-    "userpoolClientRefreshTokenValidity": 30,
-    "userpoolClientWriteAttributes": [
+    "userPoolClientGenerateSecret": false,
+    "userPoolClientRefreshTokenValidity": 30,
+    "userPoolClientWriteAttributes": [
       "email"
     ],
-    "userpoolClientReadAttributes": [
+    "userPoolClientReadAttributes": [
       "email"
     ],
-    "userpoolClientLambdaRole": "visitc71d203dc_userpoolclient_lambda_role",
-    "userpoolClientSetAttributes": false,
+    "userPoolClientLambdaRole": "visitc71d203dc_userpoolclient_lambda_role",
+    "userPoolClientSetAttributes": false,
     "sharedId": "71d203dc",
     "resourceName": "visitchicago71d203dc",
     "authSelections": "identityPoolAndUserPool",


### PR DESCRIPTION
## Summary
- rename `userpoolClient*` fields to `userPoolClient*` in `cli-inputs.json`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f751c6458832681a22243b18bf4bc