### PR TITLE
Fix export comment

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -112,5 +112,5 @@ const styles = {
   },
 };
 
-//export default App;
+// This component is exported wrapped in withAuthenticator below
 export default withAuthenticator(App);


### PR DESCRIPTION
## Summary
- update the comment about the default export in `App.js`

## Testing
- `npm test --silent --no-watch --no-color` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f751f443c832687c1cdf97af76abf