### PR TITLE
Transform sample todo into multi-page Chicago guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,9 @@
-# Getting Started with Create React App
+# Visit Chicago
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+A simple React site showcasing Chicago for visitors. The app includes pages for restaurants, tourist sites, nightlife, and interesting facts. Navigation is handled without external routing libraries.
 
 ## Available Scripts
 
-In the project directory, you can run:
-
-### `npm start`
-
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
-
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+- `npm start` – start the development server
+- `npm test` – run tests (none are provided)
+- `npm run build` – build for production

--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,35 @@
 .App {
+  font-family: Arial, sans-serif;
   text-align: center;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
+.nav {
+  background: #333;
+  padding: 10px;
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  gap: 10px;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
 }
 
-.App-link {
-  color: #61dafb;
+.nav button {
+  background: #fff;
+  border: none;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-radius: 4px;
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.nav button:hover {
+  background: #ddd;
+}
+
+.page {
+  padding: 20px;
+}
+
+.hero-image {
+  width: 100%;
+  max-width: 600px;
+  border-radius: 8px;
+  margin-top: 20px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,116 +1,35 @@
-/* src/App.js */
-import React, { useEffect, useState } from "react";
-import { Amplify, API, graphqlOperation } from "aws-amplify";
-import { createTodo } from "./graphql/mutations";
-import { listTodos } from "./graphql/queries";
-import {
-  withAuthenticator,
-  Button,
-  Heading,
-  Text,
-  TextField,
-  View,
-} from "@aws-amplify/ui-react";
-import "@aws-amplify/ui-react/styles.css";
+import React, { useState } from 'react';
+import './App.css';
+import Home from './pages/Home';
+import Restaurants from './pages/Restaurants';
+import TouristSites from './pages/TouristSites';
+import Nightlife from './pages/Nightlife';
+import InterestingFacts from './pages/InterestingFacts';
 
-import awsExports from "./aws-exports";
-Amplify.configure(awsExports);
+const pages = {
+  home: Home,
+  restaurants: Restaurants,
+  sites: TouristSites,
+  nightlife: Nightlife,
+  facts: InterestingFacts,
+};
 
-const initialState = { name: "", description: "" };
-
-const App = ({ signOut, user }) => {
-  const [formState, setFormState] = useState(initialState);
-  const [todos, setTodos] = useState([]);
-
-  useEffect(() => {
-    fetchTodos();
-  }, []);
-
-  function setInput(key, value) {
-    setFormState({ ...formState, [key]: value });
-  }
-
-  async function fetchTodos() {
-    try {
-      const todoData = await API.graphql(graphqlOperation(listTodos));
-      const todos = todoData.data.listTodos.items;
-      setTodos(todos);
-    } catch (err) {
-      console.log("error fetching todos");
-    }
-  }
-
-  async function addTodo() {
-    try {
-      if (!formState.name || !formState.description) return;
-      const todo = { ...formState };
-      setTodos([...todos, todo]);
-      setFormState(initialState);
-      await API.graphql(graphqlOperation(createTodo, { input: todo }));
-    } catch (err) {
-      console.log("error creating todo:", err);
-    }
-  }
+export default function App() {
+  const [page, setPage] = useState('home');
+  const CurrentPage = pages[page];
 
   return (
-    <View style={styles.container}>
-      <Heading level={1}>Hello {user.username}</Heading>
-      <Button style={styles.button} onClick={signOut}>
-        Sign out
-      </Button>
-      <Heading level={2}>Amplify Todos</Heading>
-      <TextField
-        placeholder="Name"
-        onChange={(event) => setInput("name", event.target.value)}
-        style={styles.input}
-        defaultValue={formState.name}
-      />
-      <TextField
-        placeholder="Description"
-        onChange={(event) => setInput("description", event.target.value)}
-        style={styles.input}
-        defaultValue={formState.description}
-      />
-      <Button style={styles.button} onClick={addTodo}>
-        Create Todo
-      </Button>
-      {todos.map((todo, index) => (
-        <View key={todo.id ? todo.id : index} style={styles.todo}>
-          <Text style={styles.todoName}>{todo.name}</Text>
-          <Text style={styles.todoDescription}>{todo.description}</Text>
-        </View>
-      ))}
-    </View>
+    <div className="App">
+      <nav className="nav">
+        <button onClick={() => setPage('home')}>Home</button>
+        <button onClick={() => setPage('restaurants')}>Restaurants</button>
+        <button onClick={() => setPage('sites')}>Tourist Sites</button>
+        <button onClick={() => setPage('nightlife')}>Nightlife</button>
+        <button onClick={() => setPage('facts')}>Interesting Facts</button>
+      </nav>
+      <main>
+        <CurrentPage />
+      </main>
+    </div>
   );
-};
-
-const styles = {
-  container: {
-    width: 400,
-    margin: "0 auto",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    padding: 20,
-  },
-  todo: { marginBottom: 15 },
-  input: {
-    border: "none",
-    backgroundColor: "#ddd",
-    marginBottom: 10,
-    padding: 8,
-    fontSize: 18,
-  },
-  todoName: { fontSize: 20, fontWeight: "bold" },
-  todoDescription: { marginBottom: 0 },
-  button: {
-    backgroundColor: "black",
-    color: "white",
-    outline: "none",
-    fontSize: 18,
-    padding: "12px 0px",
-  },
-};
-
-//export default App;
-export default withAuthenticator(App);
+}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders welcome message', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/welcome to chicago/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,14 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import "./index.css";
-import App from "./App";
-import reportWebVitals from "./reportWebVitals";
-import { Amplify } from "aws-amplify";
-import awsExports from "./aws-exports";
-Amplify.configure(awsExports);
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
+import reportWebVitals from './reportWebVitals';
 
-const root = ReactDOM.createRoot(document.getElementById("root"));
+const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
 );
 
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function Home() {
+  return (
+    <div className="page">
+      <h1>Welcome to Chicago</h1>
+      <p>Explore the best restaurants, famous attractions, lively nightlife, and quirky facts about the Windy City.</p>
+      <img
+        src="https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=800&q=60"
+        alt="Chicago skyline"
+        className="hero-image"
+      />
+    </div>
+  );
+}

--- a/src/pages/InterestingFacts.js
+++ b/src/pages/InterestingFacts.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default function InterestingFacts() {
+  const facts = [
+    'Chicago reversed the flow of its river in 1900.',
+    'The first skyscraper was built here in 1885.',
+    'Route 66 begins in Chicago at Grant Park.',
+  ];
+  return (
+    <div className="page">
+      <h1>Interesting Facts</h1>
+      <ul>
+        {facts.map((f, i) => (
+          <li key={i}>{f}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/Nightlife.js
+++ b/src/pages/Nightlife.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function Nightlife() {
+  const spots = [
+    { name: 'The Green Mill', desc: 'Historic jazz club in Uptown.' },
+    { name: 'Kingston Mines', desc: 'Blues bar with live music every night.' },
+    { name: 'Three Dots and a Dash', desc: 'Speakeasy-style tiki bar.' },
+  ];
+  return (
+    <div className="page">
+      <h1>Nightlife</h1>
+      <ul>
+        {spots.map((s) => (
+          <li key={s.name}>
+            <strong>{s.name}</strong> - {s.desc}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/Restaurants.js
+++ b/src/pages/Restaurants.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function Restaurants() {
+  const places = [
+    { name: 'Giordano\'s', desc: 'Classic deep dish pizza.' },
+    { name: 'Portillo\'s', desc: 'Famous for Chicago-style hot dogs.' },
+    { name: 'Girl & the Goat', desc: 'Trendy spot with creative small plates.' },
+  ];
+  return (
+    <div className="page">
+      <h1>Restaurants</h1>
+      <ul>
+        {places.map((p) => (
+          <li key={p.name}>
+            <strong>{p.name}</strong> - {p.desc}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/TouristSites.js
+++ b/src/pages/TouristSites.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function TouristSites() {
+  const sites = [
+    { name: 'Millennium Park', desc: 'Home of the famous “Bean” sculpture.' },
+    { name: 'Navy Pier', desc: 'Attractions, restaurants, and lakefront views.' },
+    { name: 'Art Institute of Chicago', desc: 'World-class art collections.' },
+  ];
+  return (
+    <div className="page">
+      <h1>Tourist Sites</h1>
+      <ul>
+        {sites.map((s) => (
+          <li key={s.name}>
+            <strong>{s.name}</strong> - {s.desc}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace Amplify todo app with simple navigation-based Chicago guide
- add pages for Home, Restaurants, Tourist Sites, Nightlife, and Interesting Facts
- implement navigation bar and basic styling
- update tests to match new homepage content
- simplify README

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7d91f0308326a873fe2c61d7217a