### PR TITLE
Add Chicago-themed header styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -112,7 +112,7 @@ header {
 }
 
 .hero-text h1 {
-  color: var(--burnt2);
+  color: var(--gray2);
   margin-bottom: 10px;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -21,6 +21,17 @@ header {
 .site-title {
   margin: 0;
   color: var(--blue2);
+  border-top: 4px solid var(--blue2);
+  border-bottom: 4px solid var(--blue2);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+}
+
+.flag-star {
+  color: var(--burnt2);
+  font-size: 1.2rem;
 }
 
 .nav {

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,13 @@ export default function App() {
   return (
     <div className="App">
       <header>
-        <h1 className="site-title">Chicago Guide</h1>
+        <h1 className="site-title">
+          <span className="flag-star">✶</span>
+          <span className="flag-star">✶</span>
+          Chicago Guide
+          <span className="flag-star">✶</span>
+          <span className="flag-star">✶</span>
+        </h1>
         <nav className="nav">
           <button
             className={page === 'home' ? 'active' : ''}


### PR DESCRIPTION
## Summary
- style header title to include Chicago flag stars and stripes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840f701b8008326ad16639a1b396163